### PR TITLE
openocd/digilent-arty: use existing digilent-hs1.cfg as programmer

### DIFF
--- a/openocd/digilent-arty.patch
+++ b/openocd/digilent-arty.patch
@@ -1,28 +1,16 @@
 diff --git a/tcl/board/digilent_arty.cfg b/tcl/board/digilent_arty.cfg
 new file mode 100644
-index 00000000..317e7d26
+index 00000000..cd50ecd1
 --- /dev/null
-+++ tcl/board/digilent_arty.cfg
-@@ -0,0 +1,22 @@
++++ b/tcl/board/digilent_arty.cfg
+@@ -0,0 +1,10 @@
 +#
 +# Digilent Arty with Xilinx Artix-7 FPGA
 +#
 +# http://store.digilentinc.com/arty-artix-7-fpga-development-board-for-makers-and-hobbyists/
 +#
 +
-+# iManufacturer           1 Digilent
-+# iProduct                2 Digilent USB Device
-+# iSerial                 3 210319A28C7F
-+
-+interface ftdi
-+ftdi_device_desc "Digilent USB Device"
-+ftdi_vid_pid 0x0403 0x6010
-+# channel 1 does not have any functionality
-+ftdi_channel 0
-+# just TCK TDI TDO TMS, no reset
-+ftdi_layout_init 0x0088 0x008b
-+reset_config none
-+adapter_khz 10000
-+
++source [find interface/ftdi/digilent-hs1.cfg]
 +source [find cpld/xilinx-xc7.cfg]
 +source [find cpld/jtagspi.cfg]
++adapter_khz 10000


### PR DESCRIPTION
The programmer definition was a copy of the digilent-hs1 programmer, so replace
this with sourcing the programmer definition file.