### PR TITLE
Add Spartan 7 IDCODEs check

### DIFF
--- a/openocd/meta.yaml
+++ b/openocd/meta.yaml
@@ -14,6 +14,7 @@ source:
     - numato-saturn.patch
     - numato-waxwing.patch
     - fpga-program.patch
+    - spartan7-idcodes.patch
 
 build:
   number: 0

--- a/openocd/spartan7-idcodes.patch
+++ b/openocd/spartan7-idcodes.patch
@@ -1,0 +1,20 @@
+diff --git a/tcl/cpld/xilinx-xc7.cfg b/tcl/cpld/xilinx-xc7.cfg
+index d5824f8..4c0502c 100644
+--- a/tcl/cpld/xilinx-xc7.cfg
++++ b/tcl/cpld/xilinx-xc7.cfg
+@@ -9,7 +9,15 @@
+ 
+ # the 4 top bits (28:31) are the die stepping/revisions. ignore it.
+ jtag newtap $_CHIPNAME tap -irlen 6 -ignore-version \
++	-expected-id 0x03622093 \
++	-expected-id 0x03620093 \
++	-expected-id 0x037C4093 \
++	-expected-id 0x0362F093 \
++	-expected-id 0x037C8093 \
++	-expected-id 0x037C7093 \
++	-expected-id 0x037C3093 \
+ 	-expected-id 0x0362E093 \
++	-expected-id 0x037C2093 \
+ 	-expected-id 0x0362D093 \
+ 	-expected-id 0x0362C093 \
+ 	-expected-id 0x03632093 \


### PR DESCRIPTION
Squelch the misleading errors that OpenOCD emits when programming Spartan 7 devices, since upstream OpenOCD currently doesn't expect their IDCODEs.

This fixes the error @mhanuel26 was [seeing](https://github.com/fupy/issues-wiki/issues/9#issue-297336863).