### PR TITLE
Add Arty S7 board to OpenOCD Conda Package

### DIFF
--- a/openocd/digilent-arty-s7.patch
+++ b/openocd/digilent-arty-s7.patch
@@ -1,0 +1,45 @@
+diff --git a/tcl/board/arty_s7.cfg b/tcl/board/arty_s7.cfg
+new file mode 100644
+index 0000000..563fb28
+--- /dev/null
++++ tcl/board/arty_s7.cfg
+@@ -0,0 +1,39 @@
++#
++# Arty S7: Spartan7 25/50 FPGA Board for Makers and Hobbyists
++#
++# https://www.xilinx.com/products/boards-and-kits/1-pnziih.html
++# https://store.digilentinc.com/arty-s7-spartan-7-fpga-board-for-makers-and-hobbyists/
++
++source [find interface/ftdi/digilent-hs1.cfg]
++
++# Xilinx Spartan7-25/50 FPGA (XC7S{25,50}-CSGA324)
++source [find cpld/xilinx-xc7.cfg]
++source [find cpld/jtagspi.cfg]
++
++adapter_khz 25000
++
++# This configuration can only be used to load bitstreams either to the FPGA
++# via JTAG, or writing to an SPI flash via a jtagspi proxy. This configuration
++# cannot be used for debugging a target FPGA.
++#
++# Usage:
++#
++# Load Bitstream into FPGA:
++#    openocd -f board/arty_s7.cfg -c "init;\
++#    pld load 0 bitstream.bit;\
++#    shutdown"
++#
++# Write Bitstream to Flash:
++#    openocd -f board/arty_s7.cfg -c "init;\
++#    jtagspi_init 0 bscan_spi_xc7s??.bit;\
++#    jtagspi_program bitstream.bin 0;\
++#    xc7s_program xc7s.tap;\
++#    shutdown"
++#
++# jtagspi flash proxies can be found at:
++# https://github.com/quartiq/bscan_spi_bitstreams
++#
++# For the Spartan 50 variant, use
++#  - https://github.com/quartiq/bscan_spi_bitstreams/raw/master/bscan_spi_xc7s50.bit
++# For the Spartan 25 variant, use
++#  - https://github.com/quartiq/bscan_spi_bitstreams/raw/master/bscan_spi_xc7s25.bit

--- a/openocd/meta.yaml
+++ b/openocd/meta.yaml
@@ -7,6 +7,7 @@ source:
   git_url: git://repo.or.cz/openocd.git
   patches:
     - digilent-arty.patch
+    - digilent-arty-s7.patch
     - digilent-cmod-a7.patch
     - digilent-nexys_video.patch
     - gadgetfactory-papilio_duo.patch


### PR DESCRIPTION
Somehow this completely escaped my mind to do until now :(. This tracks the following patch upstream: http://openocd.zylin.com/#/c/4525/

My previous PR (_still_ waiting for upstream to review) is: http://openocd.zylin.com/#/c/4428/