### PR TITLE
vtr: Build from SymbiFlow branch on SymbiFlow repo.

### DIFF
--- a/vtr/meta.yaml
+++ b/vtr/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: {{ GIT_DESCRIBE_TAG|replace('vpr-','') }}
 
 source:
-  git_url: https://github.com/mithro/vtr-verilog-to-routing.git
-  git_rev: master
+  git_url: https://github.com/SymbiFlow/vtr-verilog-to-routing.git
+  git_rev: symbiflow
 
 build:
   # y==GIT_DESCRIBE_NUMBER, z==DATESTR, x==GIT_DESCRIBE_HASH


### PR DESCRIPTION
 * https://github.com/SymbiFlow/vtr-verilog-to-routing