### PR TITLE
Small fixes to GCC packages

### DIFF
--- a/lm32/gcc-newlib/meta.yaml
+++ b/lm32/gcc-newlib/meta.yaml
@@ -8,6 +8,7 @@ source:
   sha256: 608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a
   patches:
    - stdint.patch
+   - reload1.patch
 
 extra:
   sources:

--- a/lm32/gcc-newlib/reload1.patch
+++ b/lm32/gcc-newlib/reload1.patch
@@ -1,0 +1,11 @@
+--- a/gcc/reload1.c	2018-01-18 05:48:44.640984629 -0800
++++ b/gcc/reload1.c	2018-01-18 05:50:14.951908013 -0800
+@@ -467,7 +467,7 @@
+ 
+   while (memory_address_p (QImode, tem))
+     {
+-      spill_indirect_levels++;
++      spill_indirect_levels += 1;
+       tem = gen_rtx_MEM (Pmode, tem);
+     }
+ 

--- a/lm32/gcc-nostdc/build.sh
+++ b/lm32/gcc-nostdc/build.sh
@@ -33,6 +33,7 @@ mkdir -p build-gcc
 cd build-gcc
 
 # --without-headers - Tells GCC not to rely on any C library (standard or runtime) being present for the target.
+CFLAGS=-Wno-literal-suffix
 #export LDFLAGS=-static
 $SRC_DIR/configure \
         --prefix=$PREFIX \

--- a/lm32/gcc-nostdc/meta.yaml
+++ b/lm32/gcc-nostdc/meta.yaml
@@ -8,6 +8,7 @@ source:
   sha256: 608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a
   patches:
    - stdint.patch
+   - reload1.patch
 
 build:
   detect_binary_files_with_prefix: False

--- a/lm32/gcc-nostdc/reload1.patch
+++ b/lm32/gcc-nostdc/reload1.patch
@@ -1,0 +1,11 @@
+--- a/gcc/reload1.c	2018-01-18 05:48:44.640984629 -0800
++++ b/gcc/reload1.c	2018-01-18 05:50:14.951908013 -0800
+@@ -467,7 +467,7 @@
+ 
+   while (memory_address_p (QImode, tem))
+     {
+-      spill_indirect_levels++;
++      spill_indirect_levels += 1;
+       tem = gen_rtx_MEM (Pmode, tem);
+     }
+ 

--- a/or1k/gcc-newlib/meta.yaml
+++ b/or1k/gcc-newlib/meta.yaml
@@ -5,6 +5,8 @@ package:
 source:
   git_url: https://github.com/openrisc/or1k-gcc.git
   git_rev: or1k-5.4.0
+  patches:
+   - reload1.patch
 
 extra:
   sources:

--- a/or1k/gcc-newlib/reload1.patch
+++ b/or1k/gcc-newlib/reload1.patch
@@ -1,0 +1,11 @@
+--- a/gcc/reload1.c	2018-01-18 05:48:44.640984629 -0800
++++ b/gcc/reload1.c	2018-01-18 05:50:14.951908013 -0800
+@@ -467,7 +467,7 @@
+ 
+   while (memory_address_p (QImode, tem))
+     {
+-      spill_indirect_levels++;
++      spill_indirect_levels += 1;
+       tem = gen_rtx_MEM (Pmode, tem);
+     }
+ 

--- a/or1k/gcc-nostdc/meta.yaml
+++ b/or1k/gcc-nostdc/meta.yaml
@@ -5,6 +5,8 @@ package:
 source:
   git_url: https://github.com/openrisc/or1k-gcc.git
   git_rev: or1k-5.4.0
+  patches:
+   - reload1.patch
 
 build:
   detect_binary_files_with_prefix: False

--- a/or1k/gcc-nostdc/reload1.patch
+++ b/or1k/gcc-nostdc/reload1.patch
@@ -1,0 +1,11 @@
+--- a/gcc/reload1.c	2018-01-18 05:48:44.640984629 -0800
++++ b/gcc/reload1.c	2018-01-18 05:50:14.951908013 -0800
+@@ -467,7 +467,7 @@
+ 
+   while (memory_address_p (QImode, tem))
+     {
+-      spill_indirect_levels++;
++      spill_indirect_levels += 1;
+       tem = gen_rtx_MEM (Pmode, tem);
+     }
+ 


### PR DESCRIPTION
Probably doesn't work as the packages required the older conda-build which is no longer supported.