### PR TITLE
gcc: Don't use -static to build.

### DIFF
--- a/lm32/gcc-newlib/build.sh
+++ b/lm32/gcc-newlib/build.sh
@@ -56,7 +56,7 @@ cd ..
 
 mkdir -p build-gcc
 cd build-gcc
-export LDFLAGS=-static
+#export LDFLAGS=-static
 $SRC_DIR/configure \
 	\
 	--program-prefix=$TARGET-newlib- \

--- a/lm32/gcc-nostdc/build.sh
+++ b/lm32/gcc-nostdc/build.sh
@@ -33,7 +33,7 @@ mkdir -p build-gcc
 cd build-gcc
 
 # --without-headers - Tells GCC not to rely on any C library (standard or runtime) being present for the target.
-export LDFLAGS=-static
+#export LDFLAGS=-static
 $SRC_DIR/configure \
         --prefix=$PREFIX \
         --with-gmp=$PREFIX \

--- a/or1k/gcc-newlib/build.sh
+++ b/or1k/gcc-newlib/build.sh
@@ -85,7 +85,7 @@ cd ..
 
 mkdir -p build-gcc
 cd build-gcc
-export LDFLAGS=-static
+#export LDFLAGS=-static
 $SRC_DIR/configure \
 	\
 	--program-prefix=$TARGET-newlib- \

--- a/or1k/gcc-nostdc/build.sh
+++ b/or1k/gcc-nostdc/build.sh
@@ -59,7 +59,7 @@ mkdir -p build-gcc
 cd build-gcc
 
 # --without-headers - Tells GCC not to rely on any C library (standard or runtime) being present for the target.
-export LDFLAGS=-static
+#export LDFLAGS=-static
 $SRC_DIR/configure \
         --prefix=$PREFIX \
         --with-gmp=$PREFIX \


### PR DESCRIPTION
The `-static` causes the following vsyscall error;
```
[302959.853380] lm32-elf-gcc[150321] vsyscall attempted with vsyscall=none ip:ffffffffff600000 cs:33 sp:7fffa1920dd8 ax:ffffffffff600000 si:0 di:7fffa1920e00
```
