### PR TITLE
README: Document Travis CI / local conda builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,97 @@ Current versions are;
 
 Tool for JTAG programming.
 
+# Building
+
+This repository is set up to be built by Travis CI, using the GitHub
+integration to Travis CI.
+
+See [`.travis.yml`](.travis.yml) for the build configuration given to
+Travis CI, and the [`.travis`](.travis) directory for scripts referenced.
+
+The Travis CI output can be found on the https://travis-ci.org/ for the
+GitHub account and GitHub repository.  For instance, for the main:
+
+https://github.com/timvideos/conda-hdmi2usb-packages
+
+GitHub repository, the Travis CI results can be seen at:
+
+https://travis-ci.org/timvideos/conda-hdmi2usb-packages
+
+And if you enable Travis CI on your GitHub fork of `conda-hdmi2usb-packages`
+then your Travis CI results will be at:
+
+```
+https://travis-ci.org/${GITHUB\_USER}/conda-hdmi2usb-packages
+```
+
+If the build fails, see the [common Travis CI build
+problems](https://docs.travis-ci.com/user/common-build-problems/)
+for assistance investigating the issues.  Common issues with this
+repository include package dependencies (eg, where Conda has changed),
+output log file size (Travis CI has a 4MB maximum, and some package
+builds like `gcc` generate a *lot* of output), and builds timing out
+(either for maximum time allocation, or for ["no output" for more than
+10 minutes](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received)).
+
+## Testing conda builds locally
+
+Given a fairly empty *disposable* Ubuntu x86-64 test environment (eg,
+created with Docker, or Vagrant), it is possible to simulate *part* of
+what Travis CI will do to test building individual toolchain architectures
+locally.
+
+This can be done with something like:
+
+```
+sudo apt-get update
+sudo apt-get install wget git
+
+# Packages from ~/.travis.yml; realpath is in coreutils in Ubuntu 18.04
+#sudo apt-get install realpath autoconf automake build-essential gperf libftdi-dev libudev-dev libudev1 libusb-1.0-0-dev libusb-dev texinfo
+sudo apt-get install coreutils autoconf automake build-essential gperf libftdi-dev libudev-dev libudev1 libusb-1.0-0-dev libusb-dev texinfo
+
+git clone https://github.com/timvideos/conda-hdmi2usb-packages.git
+conda-hdmi2usb-packages/conda-get.sh
+
+# Adapted from .travis/common.sh
+get_built_package() {
+   ./conda-env.sh render --output "$@" 2>/dev/null | grep conda-bld | grep tar.bz2 | tail -n 1 | sed -e's/-[0-9]\+\.tar/*.tar/' -e's/-git//'
+}
+
+# Anchor the build date/time, so we have predictable filenames
+export DATE_NUM="$(date -u +%Y%m%d%H%M%S)"
+export DATE_STR="$(date -u +%Y%m%d_%H%M%S)"
+
+# Combinations taken from .travis.yml
+TOOLCHAIN_ARCH=lm32
+export PACKAGE TOOLCHAIN_ARCH
+
+cd conda-hdmi2usb-packages
+
+for PACKAGE in binutils gcc/nostdc gcc/newlib; do
+  ./conda-env.sh build --check "${PACKAGE}"   # Downloads and caches stuff
+  ./conda-env.sh build         "${PACKAGE}"   # Actually build package
+  CONDA_OUT="$(get_built_package ${PACKAGE})" # Calculate output package
+  ./conda-env.sh install       "${CONDA_OUT}"
+done
+```
+
+Expect packages like `binutils` to take 3-5 minutes to build, packages
+like `gcc/nostdc` to take 10-15 minutes to build, and packages like
+`gcc/newlib` to take 25-40 minutes to build, on a relatively fast
+build system (eg, SSD, i7, reasonable amount of RAM).  Beware that
+`gcc/newlib` wants to see `gcc/nostdc` *of the same version* already
+installed before it will build; this means that `gcc/newlib` is
+non-trivial to build individually.
+
+To build one architecture of tools, without any cleanup will need a
+VM with maybe 12-15GiB of space available (a 10GiB disk image is not
+quite big enough). Building more architectures at once will need more
+disk space.
+
+**NOTE**: By preference only packages built by Travis CI should be
+uploaded to the Anaconda repository, so that the externally visible
+packages have consistent package versions (and do not conflict).  But
+it can be useful to build locally to debug `conda-build` config issues
+without waiting for a full Travis CI cycle.


### PR DESCRIPTION
Add notes to `README.md` to point readers to (a) where to expect the build output so they can check build status more easily, and (b) a sketch of how to try conda builds locally (determined by reverse engineering what Travis CI was being given / examining the shell scripts at the top level).

With something like the example given in this commit I've been able to build `lm32` `binutils`, `gcc/nostdc` `gcc/newlib`, taking roughly an hour of clock time (plus a few more hours of yak shaving figuring out how to get it set up).  Most of that time is disk IO from the looks (only about 8 minutes of CPU time).  Built on a Vagrant Ubuntu 18.04 x86-64 VM, with solid state disk, and i7 CPU.  (Just building those three needs about 12-15GiB of space in the VM; 10GiB for the VM disk didn't seem to be quite enough as the `gcc/newlib` build -- the third step -- failed to start.)

```
binutils build resources:

Total time: 0:02:00.4
CPU usage: sys=0:00:01.0, user=0:00:09.6
Maximum memory usage observed: 203.8M
Total disk usage observed (not including envs): 324.8K


gcc/nostdcc build resources:

Total time: 0:12:32.1
CPU usage: sys=0:00:09.1, user=0:03:38.6
Maximum memory usage observed: 535.2M
Total disk usage observed (not including envs): 731.7K


gcc/newlib build resources:

Total time: 0:27:00.9
CPU usage: sys=0:00:10.9, user=0:03:36.8
Maximum memory usage observed: 529.8M
Total disk usage observed (not including envs): 828.1K
```