### PR TITLE
flterm: Remove C++ dependency, reduce runtime deps

### DIFF
--- a/flterm/meta.yaml
+++ b/flterm/meta.yaml
@@ -19,12 +19,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   run:
   {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
-  {% for package in resolved_packages('build') %}
     - {{ package }}
   {% endfor %}
 


### PR DESCRIPTION
flterm is written in C, it does not need a C++ compiler installed.
Also, listing strict build time dependencies as runtime dependencies
(a) drags in a lot of stuff, and (b) causes weird end user upgrade
dependencies, so remove that.

Difference in resulting dependencies is huge:

```
vagrant@conda:~/conda-hdmi2usb-packages$ diff /tmp/flterm.dep.before /tmp/flterm.dep.after 
10c10
< {'c_compiler': 'gcc', 'cxx_compiler': 'gxx'}
---
> {'c_compiler': 'gcc'}
27a28
>         - gcc_linux-64 7.3.0 h553295d_6
29d29
<         - gxx_linux-64 7.3.0 h553295d_6
31,33d30
<         - gcc_linux-64 7.3.0 h553295d_6
<         - gxx_impl_linux-64 7.3.0 hdf63c60_1
<         - libgcc-ng 8.2.0 hdf63c60_1
34a32
>         - libgcc-ng 8.2.0 hdf63c60_1
37d34
<         - libstdcxx-ng 8.2.0 hdf63c60_1
39,46c36
<         - binutils_impl_linux-64 2.31.1 h6176602_1
<         - libstdcxx-ng 8.2.0 hdf63c60_1
<         - gxx_linux-64 7.3.0 h553295d_6
<         - gcc_impl_linux-64 7.3.0 habb00fd_1
<         - libgcc-ng 8.2.0 hdf63c60_1
<         - gcc_linux-64 7.3.0 h553295d_6
<         - gxx_impl_linux-64 7.3.0 hdf63c60_1
<         - binutils_linux-64 2.31.1 h6176602_6
---
>         - libgcc-ng >=7.3.0
vagrant@conda:~/conda-hdmi2usb-packages$ 
```

and in particular looks like it avoids dragging in the binutils dependency on which the Conda C compiler was built, which we have no need to depend on at runtime.  (Most of the volume reduction in build dependencies is from not depending on C++ compiler at all.)

At minimum this gets us *closer* to `conda update --all` not wanting to downgrade lots of stuff to upgrade binutils.  (And maybe we need to do something similar with our `-newlib` builds too?)

Ewen