### PR TITLE
gcc/newlib: more flexible runtime dependencies

### DIFF
--- a/gcc/newlib/meta.yaml
+++ b/gcc/newlib/meta.yaml
@@ -53,9 +53,6 @@ requirements:
   run:
     - binutils-{{ environ.get('TOOLCHAIN_ARCH') }}-elf
     - gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-elf-nostdc {{ version }}.*
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
 
 about:
   home: https://gcc.gnu.org/


### PR DESCRIPTION
As foreshadowed in https://github.com/timvideos/conda-hdmi2usb-packages/pull/65#issuecomment-468093967

Remove `resolved_packages('host')` package lock runtime dependencies, so as to allow more flexible automatic dependencies on the `gcc/newlib` packages, and thus fewer version conflicts on doing upgrades.  Most of the actually required dependencies will be transitively pulled in via requiring `gcc/nostdc` *anyway*.

Builds okay here locally for `lm32`:

```
vagrant@conda:~/conda-hdmi2usb-packages$ echo $DATE_STR
20190228_004924
vagrant@conda:~/conda-hdmi2usb-packages$ ./conda-env.sh list | grep lm32
binutils-lm32-elf         2.31.1          20190228_004924    local
gcc-lm32-elf-newlib       8.2.0           20190228_004924    local
gcc-lm32-elf-nostdc       8.2.0           20190228_004924    local
vagrant@conda:~/conda-hdmi2usb-packages$ 
```